### PR TITLE
Issue assets frontend fixed

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -1,0 +1,28 @@
+{
+    'name': 'Custom Snippets',
+    'category': 'Website/Website',
+    'sequence': 51,
+    'summary': 'Adds custom snippets website',
+    'version': '1.0',
+    'description': "",
+    'depends': ['website', 'website_sale', 'web'],
+    'qweb': ['static/src/xml/*.xml'],
+    'data': [
+        'views/snippets/snippets.xml',
+        'views/snippets/s_cart_products.xml',
+    ],
+
+    # assets
+    'assets':{
+        "web.assets_frontend":[
+            "/custom_snippets/static/src/snippets/s_cart_products/000.js",
+        ],
+
+        "web.assets_editor":[
+            "/custom_snippets/static/src/snippets/s_cart_products/options.js",
+        ],
+    },
+
+    'installable': True,
+    'application': True,
+}

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/controllers/main.py
+++ b/controllers/main.py
@@ -1,0 +1,13 @@
+from odoo import http
+from odoo.http import request
+
+class CustomSnippets(http.Controller):
+    @http.route(['/custom_snippets/cart_content'], type='json', auth="public", website=True)
+    def cart(self):
+        products = request.website.sale_get_order().order_line.product_id
+        data = []
+        for product in products:
+            fields = product.read(['display_name', 'description_sale', 'list_price', 'website_url'])[0];
+            fields['image'] = request.env['website'].image_url(product, 'image_512')
+            data.append(fields)
+        return request.env['ir.ui.view']._render_template('custom_snippets.s_cart_products_card', {'products': data})

--- a/custom_snippets/__manifest__.py
+++ b/custom_snippets/__manifest__.py
@@ -5,12 +5,24 @@
     'summary': 'Adds custom snippets website',
     'version': '1.0',
     'description': "",
-    'depends': ['website_sale'],
+    'depends': ['website', 'website_sale', 'web'],
     'qweb': ['static/src/xml/*.xml'],
     'data': [
         'views/snippets/snippets.xml',
         'views/snippets/s_cart_products.xml',
     ],
+
+    # assets
+    'assets':{
+        "web.assets_frontend":[
+            "/custom_snippets/static/src/snippets/s_cart_products/000.js",
+        ],
+
+        "web.assets_editor":[
+            "/custom_snippets/static/src/snippets/s_cart_products/options.js",
+        ],
+    },
+
     'installable': True,
     'application': True,
 }

--- a/custom_snippets/views/snippets/snippets.xml
+++ b/custom_snippets/views/snippets/snippets.xml
@@ -27,7 +27,7 @@
         <t t-snippet="custom_snippets.s_cart_products" t-thumbnail="/website_sale/static/src/img/snippets_thumbs/s_products_recently_viewed.svg"/>
     </xpath>
 </template>
-
+<!-- 
 <template id="assets_snippet_s_cart_products_js_000" inherit_id="website.assets_frontend">
     <xpath expr="//script[last()]" position="after">
         <script type="text/javascript" src="/custom_snippets/static/src/snippets/s_cart_products/000.js"/>
@@ -39,5 +39,6 @@
         <script type="text/javascript" src="/custom_snippets/static/src/snippets/s_cart_products/options.js"/>
     </xpath>
 </template>
+-->
 
 </odoo>

--- a/static/src/snippets/s_cart_products/000.js
+++ b/static/src/snippets/s_cart_products/000.js
@@ -1,0 +1,24 @@
+odoo.define('custom_snippets.s_cart_products', function (require) {
+'use strict';
+
+const publicWidget = require('web.public.widget');
+const DynamicSnippetCarousel = require('website.s_dynamic_snippet_carousel');
+
+publicWidget.registry.dynamic_snippet_products = DynamicSnippetCarousel.extend({
+    selector: '.s_cart_products',
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    _fetchData: async function () {
+        const cards = await this._rpc({
+            route: '/custom_snippets/cart_content',
+        });
+        this.data = [...$(cards)].filter(node => node.nodeType === 1).map(el => el.outerHTML);
+    },
+});
+});

--- a/static/src/snippets/s_cart_products/options.js
+++ b/static/src/snippets/s_cart_products/options.js
@@ -1,0 +1,18 @@
+odoo.define('custom_snippets.snippet.options', function (require) {
+'use strict';
+
+const options = require('web_editor.snippets.options');
+
+options.registry.CartProductsOptions = options.Class.extend({
+    //--------------------------------------------------------------------------
+    // Options
+    //--------------------------------------------------------------------------
+
+    /**
+     * @see this.selectClass for parameters
+     */
+    logStuff(previewMode, widgetValue, params) {
+        console.log(previewMode, widgetValue, params);
+    }
+});
+});

--- a/views/snippets/s_cart_products.xml
+++ b/views/snippets/s_cart_products.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_cart_products" name="Products in Cart">
+    <section class="s_cart_products pt24 pb24" data-number-of-elements="3" data-number-of-elements-small-devices="1">
+        <div class="container">
+            <h3 class="text-center mb32">Products in your Cart</h3>
+            <div class="dynamic_snippet_template o_not_editable"/>
+        </div>
+    </section>
+</template>
+
+<template id="s_cart_products_card" name="Header Image Footer Card">
+    <t t-foreach="products" t-as="product">
+        <div class="card h-100" t-att-data-url="product['website_url']">
+            <h5 class="card-header" t-esc="product['display_name']"/>
+            <div class="card-body">
+                <img class="card-img-top p-3" loading="lazy" t-att-src="product['image']"/>
+                <div class="card-text">
+                    <t t-esc="product['description_sale']"/>
+                </div>
+            </div>
+            <div class="card-footer d-flex align-items-center">
+                <div class="card-text">
+                    <t t-raw="product['list_price']"/>
+                </div>
+            </div>
+        </div>
+    </t>
+</template>
+
+</odoo>

--- a/views/snippets/snippets.xml
+++ b/views/snippets/snippets.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_dynamic_snippet_options" inherit_id="website.snippet_options">
+    <xpath expr="." position="inside">
+        <div data-js="CartProductsOptions" data-selector=".s_cart_products" data-no-preview="true">
+            <we-button data-log-stuff="hello">Log stuff</we-button>
+            <we-title class="mt-2">Number of products</we-title>
+            <we-select string="⌙ Normal devices" data-attribute-name="numberOfElements" data-no-preview="true">
+                <we-button data-select-data-attribute="1">1</we-button>
+                <we-button data-select-data-attribute="2">2</we-button>
+                <we-button data-select-data-attribute="3">3</we-button>
+                <we-button data-select-data-attribute="4">4</we-button>
+                <we-button data-select-data-attribute="6">6</we-button>
+            </we-select>
+            <we-select string="⌙ Small devices" data-attribute-name="numberOfElementsSmallDevices" data-no-preview="true">
+                <we-button data-select-data-attribute="1">1</we-button>
+                <we-button data-select-data-attribute="2">2</we-button>
+                <we-button data-select-data-attribute="3">3</we-button>
+            </we-select>
+        </div>
+    </xpath>
+</template>
+
+<template id="snippets" inherit_id="website.snippets" name="custom snippets">
+    <xpath expr="//div[@id='snippet_effect']/div[@class='o_panel_body']" position="inside">
+        <t t-snippet="custom_snippets.s_cart_products" t-thumbnail="/website_sale/static/src/img/snippets_thumbs/s_products_recently_viewed.svg"/>
+    </xpath>
+</template>
+<!-- 
+<template id="assets_snippet_s_cart_products_js_000" inherit_id="website.assets_frontend">
+    <xpath expr="//script[last()]" position="after">
+        <script type="text/javascript" src="/custom_snippets/static/src/snippets/s_cart_products/000.js"/>
+    </xpath>
+</template>
+
+<template id="assets_snippet_s_cart_products_options" inherit_id="website.assets_editor">
+    <xpath expr="//script[last()]" position="after">
+        <script type="text/javascript" src="/custom_snippets/static/src/snippets/s_cart_products/options.js"/>
+    </xpath>
+</template>
+-->
+
+</odoo>


### PR DESCRIPTION
 

Hello friends

Well, regarding the issue #1, the odoo training session was recorded in 2020, so the method of adding assets (css and js file) is not compatible with odoo 15 and that's what causes the error (`External ID not found in the system: website.assets_frontend`).

The solution, instead of referencing the assets in the xml, you have to add them in the manifest. 

[Link to the article that helped me to solve the bug](https://www.holdenrehg.com/blog/2021-10-08_odoo-manifest-asset-bundles)

